### PR TITLE
Add Javascript proxy

### DIFF
--- a/HybridWebView/HybridWebViewObjectHost.cs
+++ b/HybridWebView/HybridWebViewObjectHost.cs
@@ -1,0 +1,189 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+
+namespace HybridWebView
+{
+    // TODO:
+    // - Name converter
+    public class HybridWebViewObjectHost
+    {
+        /// <summary>
+        /// Dictionary of objects
+        /// </summary>
+        private readonly ConcurrentDictionary<string, object> _hostObjects = new();
+
+        private readonly IWebView _webView;
+
+        internal HybridWebViewObjectHost(IWebView webView)
+        {
+            _webView = webView;
+        }
+
+        /// <summary>
+        /// Event is raised when a method is invokved from JavaScript and 
+        /// no object with the matching <see cref="HybridWebViewResolveObjectEventArgs.ObjectName"/>
+        /// was found. You can call <see cref="AddObject(string, object)"/> from within this
+        /// event handler to add an object.
+        /// </summary>
+        public event EventHandler<HybridWebViewResolveObjectEventArgs> ResolveObject;
+
+        /// <summary>
+        /// Add a object with the given name
+        /// </summary>
+        /// <param name="name">name</param>
+        /// <param name="obj">object</param>
+        /// <returns>returns true if successfully added otherwise false if object with name already exists</returns>
+        public bool AddObject(string name, object obj)
+        {
+            return _hostObjects.TryAdd(name, obj);
+        }
+
+        public bool RemoveObject(string name)
+        {
+            return _hostObjects.TryRemove(name, out _);
+        }
+
+        internal void InvokeDotNetMethod(JSInvokeMethodData invokeData)
+        {
+            //TODO: validate invokeData
+            if(!_hostObjects.ContainsKey(invokeData.ClassName))
+            {
+                // Give the user an opportunity to call AddObject
+                ResolveObject?.Invoke(this, new HybridWebViewResolveObjectEventArgs { ObjectName = invokeData.ClassName, Host = this });
+            }
+
+            if(!_hostObjects.TryGetValue(invokeData.ClassName, out var target))
+            {
+                RejectCallback(invokeData.CallbackId, $"Invalid class name {invokeData.ClassName}.");
+
+                return;
+            }
+
+            var invokeMethod = target.GetType().GetMethod(invokeData.MethodName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod);
+
+            if(invokeMethod == null)
+            {
+                RejectCallback(invokeData.CallbackId, $"Invalid method {invokeData.ClassName}.{invokeData.MethodName}.");
+
+                return;
+            }
+
+            try
+            {
+                var parameters = GetMethodParams(invokeData.ClassName, invokeData.MethodName, invokeMethod, invokeData.ParamValues);
+
+                var returnValue = invokeMethod.Invoke(target, parameters);
+
+                switch (returnValue)
+                {
+                    case ValueTask valueTask:
+                        _ = ResolveTask(invokeData.CallbackId, valueTask.AsTask());
+                        break;
+
+                    case Task task:
+                        _ = ResolveTask(invokeData.CallbackId, task);
+                        break;
+
+                    default:
+                        ResolveCallback(invokeData.CallbackId, JsonSerializer.Serialize(returnValue));
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                RejectCallback(invokeData.CallbackId, ex.ToString());
+            }
+        }
+
+        private static object[] GetMethodParams(string className, string methodName, MethodInfo invokeMethod, string[] paramValues)
+        {
+            var dotNetMethodParams = invokeMethod.GetParameters();
+
+            if (dotNetMethodParams.Length == 0 && paramValues.Length == 0)
+            {
+                return null;
+            }
+
+            if (dotNetMethodParams.Length == 0 && paramValues.Length > 0)
+            {
+                throw new InvalidOperationException($"The method {className}.{methodName} takes Zero(0) parameters, was called {paramValues.Length} parameter(s).");
+            }
+
+            var hasParamArray = dotNetMethodParams.Last().GetCustomAttributes(typeof(ParamArrayAttribute), false).Length > 0;
+
+            if (hasParamArray)
+            {
+                throw new InvalidOperationException($"The method {className}.{methodName} has a parameter array as it's last argument which is not currently supported.");
+            }
+
+            if (dotNetMethodParams.Length == paramValues.Length)
+            {
+                return paramValues
+                    .Zip(dotNetMethodParams, (s, p) => JsonSerializer.Deserialize(s, p.ParameterType))
+                    .ToArray();
+            }
+
+            var methodParams = new object[dotNetMethodParams.Length];
+            var missingParams = dotNetMethodParams.Length - paramValues.Length;
+
+            for (var i = 0; i < paramValues.Length; i++)
+            {
+                var paramType = dotNetMethodParams[i].ParameterType;
+                var paramValue = paramValues[i];
+                methodParams[i] = JsonSerializer.Deserialize(paramValue, paramType);
+            }
+
+            Array.Fill(methodParams, Type.Missing, paramValues.Length, missingParams);
+
+            return methodParams;
+        }
+
+        private async Task ResolveTask(int callbackId, Task task)
+        {
+            await task;
+
+            object result = null;
+
+            if (task.GetType().IsGenericType)
+            {
+                result = task.GetType().GetProperty("Result").GetValue(task);
+            }
+
+            ResolveCallback(callbackId, JsonSerializer.Serialize(result));
+        }
+
+
+        private void ResolveCallback(int id, string json)
+        {
+            _webView.EvaluateJavaScriptAsync($"HybridWebViewDotNetHost.Current.ResolveCallback({id}, '{json}')").ContinueWith(t =>
+            {
+                if(t.Status == TaskStatus.Faulted)
+                {
+                    //TODO: Report error, add a new event maybe?
+                    var ex = t.Exception;
+                }                
+            });
+        }
+
+        private void RejectCallback(int id, string message)
+        {
+            _webView.EvaluateJavaScriptAsync($"HybridWebViewDotNetHost.Current.RejectCallback({id}, '{message}')").ContinueWith(t =>
+            {
+                if (t.Status == TaskStatus.Faulted)
+                {
+                    //TODO: Report error, add a new event maybe?
+                    var ex = t.Exception;
+                }
+            });
+        }
+
+        internal sealed class JSInvokeMethodData
+        {
+            public string ClassName { get; set; }
+            public string MethodName { get; set; }
+            public int CallbackId { get; set; }
+            public string[] ParamValues { get; set; }
+        }
+    }
+}

--- a/HybridWebView/HybridWebViewResolveObjectEventArgs.cs
+++ b/HybridWebView/HybridWebViewResolveObjectEventArgs.cs
@@ -1,0 +1,8 @@
+﻿namespace HybridWebView
+{
+    public class HybridWebViewResolveObjectEventArgs : EventArgs
+    {
+        public string ObjectName { get; init; }
+        public HybridWebViewObjectHost Host { get; init; }
+    }
+}

--- a/HybridWebView/Platforms/MacCatalyst/HybridWebViewHandler.MacCatalyst.cs
+++ b/HybridWebView/Platforms/MacCatalyst/HybridWebViewHandler.MacCatalyst.cs
@@ -22,7 +22,7 @@ namespace HybridWebView
 
         private void MessageReceived(Uri uri, string message)
         {
-            ((HybridWebView)VirtualView).OnMessageReceived(message);
+            ((HybridWebView)VirtualView).RaiseMessageReceived(message);
         }
 
         private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler

--- a/HybridWebView/Platforms/iOS/HybridWebViewHandler.iOS.cs
+++ b/HybridWebView/Platforms/iOS/HybridWebViewHandler.iOS.cs
@@ -22,7 +22,7 @@ namespace HybridWebView
 
         private void MessageReceived(Uri uri, string message)
         {
-            ((HybridWebView)VirtualView).OnMessageReceived(message);
+            ((HybridWebView)VirtualView).RaiseMessageReceived(message);
         }
 
         private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler

--- a/MauiCSharpInteropWebView/MainPage.xaml.cs
+++ b/MauiCSharpInteropWebView/MainPage.xaml.cs
@@ -11,7 +11,7 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
 
-        myHybridWebView.JSInvokeTarget = new MyJSInvokeTarget(this);
+        myHybridWebView.ObjectHost.AddObject("host", new MyJSInvokeTarget(this));
     }
 
     public string CurrentPageName => $"Current hybrid page: {_currentPage}";
@@ -68,6 +68,15 @@ public partial class MainPage : ContentPage
         public void CallMeFromScript(string message, int value)
         {
             _mainPage.WriteToLog($"I'm a .NET method called from JavaScript with message='{message}' and value={value}");
+        }
+
+        public async Task<int> CallMeFromScriptReturn(string message, int value, int? optional = 0)
+        {
+            _mainPage.WriteToLog($"I'm a .NET method called from JavaScript with message='{message}' and value={value} and optional={optional}");
+            
+            await Task.Delay(50);            
+
+            return value;
         }
     }
 

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/js/HybridWebView.js
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/js/HybridWebView.js
@@ -1,32 +1,40 @@
 ﻿// Standard methods for HybridWebView
 
-window.HybridWebView = {
-    "SendRawMessageToDotNet": function SendRawMessageToDotNet(message) {
-        window.HybridWebView.SendMessageToDotNet(0, message);
-    },
+class HybridWebViewDotNetHost {
+    // TODO: Create a psudo private constructor to allow for only
+    // a single instance of HybridWebViewDotNetHost
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#simulating_private_constructors
+    static Current = new HybridWebViewDotNetHost();
+    #nextCallbackId = 1;
+    #callbackMap = new Map();
 
-    "SendInvokeMessageToDotNet": function SendInvokeMessageToDotNet(methodName, paramValues) {
-        if (typeof paramValues !== 'undefined') {
-            if (!Array.isArray(paramValues)) {
-                paramValues = [paramValues];
-            }
-            for (var i = 0; i < paramValues.length; i++) {
-                paramValues[i] = JSON.stringify(paramValues[i]);
-            }
+    // Methods
+    SendRawMessageToDotNet(message) {
+        this.SendMessageToDotNet(0, message);
+    }
+
+    SendInvokeMessageToDotNet(className, methodName, paramValues = []) {
+        if (paramValues && !Array.isArray(paramValues)) {
+            paramValues = Array.of(paramValues);
         }
 
-        window.HybridWebView.SendMessageToDotNet(1, JSON.stringify({ "MethodName": methodName, "ParamValues": paramValues }));
-    },
+        let params = paramValues.map(x => JSON.stringify(x));
 
-    "SendMessageToDotNet": function SendMessageToDotNet(messageType, messageContent) {
+        let callback = this.CreateCallback();
+
+        this.SendMessageToDotNet(1, JSON.stringify({ "ClassName": className, "MethodName": methodName, "CallbackId": callback.id, "ParamValues": params }));
+
+        return callback.promise;
+    }
+
+    SendMessageToDotNet(messageType, messageContent) {
         var message = JSON.stringify({ "MessageType": messageType, "MessageContent": messageContent });
 
         if (window.chrome && window.chrome.webview) {
             // Windows WebView2
             window.chrome.webview.postMessage(message);
         }
-        else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop)
-        {
+        else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
             // iOS and MacCatalyst WKWebView
             window.webkit.messageHandlers.webwindowinterop.postMessage(message);
         }
@@ -35,4 +43,51 @@ window.HybridWebView = {
             hybridWebViewHost.sendMessage(message);
         }
     }
-};
+
+    CreateProxy(className) {
+        const self = this;
+        const proxy = new Proxy({}, {
+            get: function (target, methodName) {
+                return function (...args) {
+                    return self.SendInvokeMessageToDotNet(className, methodName, args);
+                }
+            }
+        });
+
+        return proxy;
+    }
+
+    ResolveCallback(id, message) {
+        const callback = this.#callbackMap.get(id);
+
+        if (callback) {
+            const obj = JSON.parse(message);
+            callback.resolve(obj);
+        }        
+    }
+
+    RejectCallback(id, message) {
+        const callback = this.#callbackMap.get(id);
+
+        if (callback) {
+            callback.resolve(message);
+        }
+    }
+
+    CreateCallback() {
+        let callback = {};
+
+        callback.id = this.#nextCallbackId++;
+        callback.promise = new Promise((resolve, reject) => {
+            callback.resolve = resolve;
+            callback.reject = reject;
+        });;
+
+        this.#callbackMap.set(callback.id, callback);
+
+        return callback;
+    }
+}
+
+// Default instance, allow users to set the instance on their own
+window.HybridWebView = HybridWebViewDotNetHost.Current;

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/methodinvoke.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/methodinvoke.html
@@ -11,10 +11,20 @@
             return sum;
         }
 
-        function CallDotNetMethod() {
+        async function CallDotNetMethod() {
             Log('Calling a method in .NET with some parameters');
 
-            HybridWebView.SendInvokeMessageToDotNet("CallMeFromScript", ["msg from js", 987]);
+            try {
+                HybridWebView.SendInvokeMessageToDotNet("host", "CallMeFromScript", ["msg from js", 987]);
+
+                const hostObj = HybridWebView.CreateProxy("host");
+                const result = await hostObj.CallMeFromScriptReturn("Hello", 42);
+
+                Log("Method call Result was " + result);
+            }
+            catch (ex) {
+                Log(ex);
+            }
         }
     </script>
     <script src="js/HybridWebView.js"></script>
@@ -30,8 +40,19 @@
         Methods can be invoked in both directions:
 
         <ul>
-            <li>JavaScript can invoke .NET methods by calling <code>HybridWebView.SendInvokeMessageToDotNet("DotNetMethodName", ["param1", 123]);</code>.</li>
             <li>.NET can invoke JavaScript methods by calling <code>var sum = await webView.InvokeJsMethodAsync<int>("JsAddNumbers", 123, 456);</code>.</li>
+            <li>
+                JavaScript can invoke .NET methods by calling
+                <code>
+                    // Call the method directly
+                    HybridWebView.SendInvokeMessageToDotNet("HostClassName", "DotNetMethodName", ["param1", 123]);
+
+                    // Create a proxy
+                    const hostObj = HybridWebView.CreateProxy("host");
+                    const result = await hostObj.CallMeFromScriptReturn("Hello", 42);
+                </code>.
+            </li>
+            
         </ul>
     </div>
     <div>

--- a/MauiReactJSHybridApp/MainPage.xaml.cs
+++ b/MauiReactJSHybridApp/MainPage.xaml.cs
@@ -13,7 +13,7 @@ namespace MauiReactJSHybridApp
             _todoDataStore = new TodoDataStore();
             _todoDataStore.TaskDataChanged += OnTodoDataChanged;
 
-            myHybridWebView.JSInvokeTarget = new TodoJSInvokeTarget(this, _todoDataStore);
+            myHybridWebView.ObjectHost.AddObject("host", new TodoJSInvokeTarget(this, _todoDataStore));
 
             BindingContext = this;
         }

--- a/README.md
+++ b/README.md
@@ -19,8 +19,19 @@ var sum = await myHybridWebView.InvokeJsMethodAsync<int>("JsAddNumbers", 123, 45
 
 And the reverse, JavaScript code calling a .NET method:
 
+```c#
+// Add an object called 'host' that can be called from JavaScript
+myHybridWebView.ObjectHost.AddObject("host", new MyJSInvokeTarget(this));
+```
+
 ```js
-HybridWebView.SendInvokeMessageToDotNet("CallMeFromScript", ["msg from js", 987]);
+// Directly call a .Net method called CallMeFromScript
+HybridWebView.SendInvokeMessageToDotNet("host", "CallMeFromScript", ["msg from js", 987]);
+
+// Create a proxy
+const myDotNetObjectProxy = HybridWebView.CreateProxy("host");
+// Call the method, await the result (promise) to get the returned value.
+const result = await myDotNetObjectProxy.CallMeFromScriptReturn("Hello", 42);
 ```
 
 In addition to method invocation, sending "raw" messages is also supported.


### PR DESCRIPTION
I had this idea a while ago to use a `Proxy` in javascript to intercept method calls and dispatch them to `.Net` using `Promises` to fulfil the method calls. This is a basic prototype of that idea, should be something that can be made to work on all supported platforms.

- Add support for creating a javascript proxy that will intercept method calls and dispatch them to .Net (returning a promise).
- Replace JSInvokeTarget with HybridWebViewObjectHost that supports multiple objects (using a string key)
- Method invocation in javascript now returns a `Promise` that can be `awaited` to obtain the result.
- Methods in `.Net` can now return a `Task` that is `awaited` and the result sent back to `javascript`.
- `OnMessageReceived` was made protected as shouldn't be called directly by user

```c#
// .Net
// Add an object called 'host' that can be called from JavaScript
myHybridWebView.ObjectHost.AddObject("host", new MyJSInvokeTarget(this));
```
```js
// JavaScript
// Directly call a .Net method called CallMeFromScript
HybridWebView.SendInvokeMessageToDotNet("host", "CallMeFromScript", ["msg from js", 987]);
// Create a proxy
const myDotNetObjectProxy = HybridWebView.CreateProxy("host");
// Call the method, await the result (promise) to get the returned value.
const result = await myDotNetObjectProxy.CallMeFromScriptReturn("Hello", 42);
```

Still lots of things I'd like to see added/supported
- [ ] ParamArray support
- [ ] Javascript -> `Net` method name conversion (should the conversion be done in `javascript` or `.Net`?)
- [ ] Javascript method names should probably be changed to start with lowercase to match `javascript` convention
- [ ] Test on all supported platforms (I've only tested on `Windows`).
- [ ] Review method/event names and properly document public `API`.
- [ ] Improved error handling
- [ ] Unit tests 